### PR TITLE
Unlock dependency for Active Record < 6.0

### DIFF
--- a/activerecord5-redshift-adapter.gemspec
+++ b/activerecord5-redshift-adapter.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.2.2'
   s.add_dependency 'pg', ['>= 0.18']
-  s.add_dependency 'activerecord', ['~> 5.0.0']
+  s.add_dependency 'activerecord', ['~> 5.0']
 end


### PR DESCRIPTION
Rails 5.1 is released.

How may I run the tests?