### PR TITLE
adjust #table_exists? to only look for tables in ROR 5.1 and remove the deprecation warning

### DIFF
--- a/lib/active_record/connection_adapters/redshift/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_statements.rb
@@ -83,13 +83,26 @@ module ActiveRecord
          # If the schema is not specified as part of +name+ then it will only find tables within
          # the current schema search path (regardless of permissions to access tables in other schemas)
          def table_exists?(name)
-          ActiveSupport::Deprecation.warn(<<-MSG.squish)
-            #table_exists? currently checks both tables and views.
-            This behavior is deprecated and will be changed with Rails 5.1 to only check tables.
-            Use #data_source_exists? instead.
-          MSG
+           if ActiveRecord.version < Gem::Version.new('5.1')
+             ActiveSupport::Deprecation.warn(<<-MSG.squish)
+               #table_exists? currently checks both tables and views.
+               This behavior is deprecated and will be changed with Rails 5.1 to only check tables.
+               Use #data_source_exists? instead.
+             MSG
+             data_source_exists?(name)
+           else
+             name = Utils.extract_schema_qualified_name(name.to_s)
+             return false unless name.identifier
 
-          data_source_exists?(name)
+             select_value(<<-SQL, 'SCHEMA').to_i > 0
+               SELECT COUNT(*)
+               FROM pg_class c
+               LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
+               WHERE c.relkind = 'r' -- (r)elation/table
+               AND c.relname = '#{name.identifier}'
+               AND n.nspname = #{name.schema ? "'#{name.schema}'" : 'ANY (current_schemas(false))'}
+             SQL
+           end
         end
 
         def data_source_exists?(name)


### PR DESCRIPTION
Title pretty much covers it.  Support for ROR 5.0 is intact.