### PR TITLE
NoDatabaseError only accepts one param

### DIFF
--- a/lib/active_record/connection_adapters/redshift_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_adapter.rb
@@ -566,7 +566,7 @@ module ActiveRecord
           configure_connection
         rescue ::PG::Error => error
           if error.message.include?("does not exist")
-            raise ActiveRecord::NoDatabaseError.new(error.message, error)
+            raise ActiveRecord::NoDatabaseError.new(error.message)
           else
             raise
           end


### PR DESCRIPTION
ActiveRecord::NoDatabaseError only accepts one parameter (the message).

Right now, when the database does not exists it is breaking with `wrong number of arguments (given 2, expected 0..1)`