### PR TITLE
forward ColumnDefinition args

### DIFF
--- a/lib/active_record/connection_adapters/redshift/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_definitions.rb
@@ -54,8 +54,8 @@ module ActiveRecord
 
         private
 
-        def create_column_definition(name, type)
-          Redshift::ColumnDefinition.new name, type
+        def create_column_definition(*args)
+          Redshift::ColumnDefinition.new *args
         end
       end
 

--- a/lib/active_record/connection_adapters/redshift/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_definitions.rb
@@ -54,8 +54,8 @@ module ActiveRecord
 
         private
 
-        def create_column_definition(name, type, opts)
-          Redshift::ColumnDefinition.new name, type, opts
+        def create_column_definition(*args)
+          Redshift::ColumnDefinition.new(*args)
         end
       end
 

--- a/lib/active_record/connection_adapters/redshift/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_definitions.rb
@@ -54,8 +54,8 @@ module ActiveRecord
 
         private
 
-        def create_column_definition(*args)
-          Redshift::ColumnDefinition.new *args
+        def create_column_definition(name, type, opts)
+          Redshift::ColumnDefinition.new name, type, opts
         end
       end
 

--- a/lib/active_record/connection_adapters/redshift/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_statements.rb
@@ -384,7 +384,7 @@ module ActiveRecord
               else raise(ActiveRecordError, "No integer type has byte size #{limit}. Use a numeric with precision 0 instead.")
             end
           else
-            super
+            super(type)
           end
         end
 


### PR DESCRIPTION
on ActiveRecord `5.4.1`, which changes ColumnDefinition to include an options param (https://github.com/rails/rails/commit/ae39b1a03d0a859be9d5342592c8936f89fcbacf) 

forwarding to the adapter then gives me:
```
ArgumentError: wrong number of arguments (given 3, expected 2)
backtrace:/usr/local/bundle/gems/activerecord5-redshift-adapter-1.0/lib/active_record/connection_adapters/redshift/schema_definitions.rb:57:in `create_column_definition'
/usr/local/bundle/gems/activerecord-5.1.4/lib/active_record/connection_adapters/abstract/schema_definitions.rb:375:in `new_column_definition'
/usr/local/bundle/gems/activerecord-5.1.4/lib/active_record/connection_adapters/abstract/schema_definitions.rb:322 
```

This PR forwards the arguments through