### PR TITLE
Rails 5.2.0 replaced binds_from_relation with arel_from_relation

### DIFF
--- a/lib/active_record/connection_adapters/redshift/database_statements.rb
+++ b/lib/active_record/connection_adapters/redshift/database_statements.rb
@@ -45,16 +45,31 @@ module ActiveRecord
         end
 
         def select_value(arel, name = nil, binds = [])
-          arel, binds = binds_from_relation arel, binds
-          sql = to_sql(arel, binds)
+          # In Rails 5.2, arel_from_relation replaced binds_from_relation,
+          # so we see which method exists to get the variables
+          if respond_to?(:arel_from_relation, false)
+            arel = arel_from_relation(arel)
+            sql, binds = to_sql(arel, binds)
+          else
+            arel, binds = binds_from_relation arel, binds
+            sql = to_sql(arel, binds)
+          end
           execute_and_clear(sql, name, binds) do |result|
             result.getvalue(0, 0) if result.ntuples > 0 && result.nfields > 0
           end
         end
 
         def select_values(arel, name = nil)
-          arel, binds = binds_from_relation arel, []
-          sql = to_sql(arel, binds)
+          # In Rails 5.2, arel_from_relation replaced binds_from_relation,
+          # so we see which method exists to get the variables
+          if respond_to?(:arel_from_relation, false)
+            arel = arel_from_relation(arel)
+            sql, binds = to_sql(arel, [])
+          else
+            arel, binds = binds_from_relation arel, []
+            sql = to_sql(arel, binds)
+          end
+
           execute_and_clear(sql, name, binds) do |result|
             if result.nfields > 0
               result.column_values(0)

--- a/lib/active_record/connection_adapters/redshift/database_statements.rb
+++ b/lib/active_record/connection_adapters/redshift/database_statements.rb
@@ -47,7 +47,7 @@ module ActiveRecord
         def select_value(arel, name = nil, binds = [])
           # In Rails 5.2, arel_from_relation replaced binds_from_relation,
           # so we see which method exists to get the variables
-          if respond_to?(:arel_from_relation, false)
+          if respond_to?(:arel_from_relation, true)
             arel = arel_from_relation(arel)
             sql, binds = to_sql(arel, binds)
           else
@@ -62,7 +62,7 @@ module ActiveRecord
         def select_values(arel, name = nil)
           # In Rails 5.2, arel_from_relation replaced binds_from_relation,
           # so we see which method exists to get the variables
-          if respond_to?(:arel_from_relation, false)
+          if respond_to?(:arel_from_relation, true)
             arel = arel_from_relation(arel)
             sql, binds = to_sql(arel, [])
           else


### PR DESCRIPTION
In this [ActiveRecord commit](https://github.com/rails/rails/commit/213796fb4936dce1da2f0c097a054e1af5c25c2c#diff-c226a4680f86689c3c170d4bc5911e96) that was released with Rails 5.2.0, the method `binds_from_relation` was replaced with `arel_from_relation`.

This change breaks the Redshift adapter.

With this patch, we look to see if the new `arel_from_relation` method exists, and if so, we use that. Otherwise we fall back to the `binds_from_relation` method.