### PR TITLE
Fixes for 5.2(?)

### DIFF
--- a/lib/active_record/connection_adapters/redshift/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_definitions.rb
@@ -54,8 +54,8 @@ module ActiveRecord
 
         private
 
-        def create_column_definition(name, type)
-          Redshift::ColumnDefinition.new name, type
+        def create_column_definition(name, type, options)
+          Redshift::ColumnDefinition.new name, type, options
         end
       end
 

--- a/lib/active_record/connection_adapters/redshift/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_statements.rb
@@ -384,7 +384,7 @@ module ActiveRecord
               else raise(ActiveRecordError, "No integer type has byte size #{limit}. Use a numeric with precision 0 instead.")
             end
           else
-            super
+            super(type)
           end
         end
 


### PR DESCRIPTION
- Using Rails 5.2.2, Activerecord 5.2.2, Ruby 2.5.1
- Ran into a few issues where AR was giving back incorrect number of params that wouldn't allow redshift to migrate

Related to #23 